### PR TITLE
Uses `Math.random()` for temporary FFmpeg filenames

### DIFF
--- a/src/lib/shared/ffmpeg/modifyWavSpeed.ts
+++ b/src/lib/shared/ffmpeg/modifyWavSpeed.ts
@@ -18,8 +18,8 @@ async function modifyWavSpeedClient(
   velocity: number,
 ): Promise<ArrayBuffer> {
   const ffmpeg = await getClientFfmpeg();
-  const inputName = `input-${crypto.randomUUID()}.wav`;
-  const outputName = `output-${crypto.randomUUID()}.mp3`;
+  const inputName = `input-${Math.random().toString(36).slice(2)}.wav`;
+  const outputName = `output-${Math.random().toString(36).slice(2)}.mp3`;
 
   ffmpeg.writeFile(inputName, new Uint8Array(wavBuffer));
 

--- a/src/lib/shared/ffmpeg/modifyWavSpeed.ts
+++ b/src/lib/shared/ffmpeg/modifyWavSpeed.ts
@@ -18,8 +18,8 @@ async function modifyWavSpeedClient(
   velocity: number,
 ): Promise<ArrayBuffer> {
   const ffmpeg = await getClientFfmpeg();
-  const inputName = `input-${Math.random().toString(36).slice(2)}.wav`;
-  const outputName = `output-${Math.random().toString(36).slice(2)}.mp3`;
+  const inputName = `input-${Date.now()}-${Math.random().toString(36).slice(2)}.wav`;
+  const outputName = `output-${Date.now()}-${Math.random().toString(36).slice(2)}.mp3`;
 
   ffmpeg.writeFile(inputName, new Uint8Array(wavBuffer));
 
@@ -27,6 +27,8 @@ async function modifyWavSpeedClient(
   await ffmpeg.exec(["-i", inputName, "-filter:a", filter, outputName]);
 
   const data = await ffmpeg.readFile(outputName, "binary");
+  await ffmpeg.deleteFile(inputName).catch(() => {});
+  await ffmpeg.deleteFile(outputName).catch(() => {});
   if (typeof data === "string") throw new Error("Se esperaba datos binarios");
   return data.buffer as ArrayBuffer;
 }

--- a/src/lib/shared/ffmpeg/wavToMp3.ts
+++ b/src/lib/shared/ffmpeg/wavToMp3.ts
@@ -7,8 +7,8 @@ export async function wavToMp3(wavBuffer: ArrayBuffer): Promise<ArrayBuffer> {
 
 async function wavToMp3Client(wavBuffer: ArrayBuffer): Promise<ArrayBuffer> {
   const ffmpeg = await getClientFfmpeg();
-  const inputName = `input-${crypto.randomUUID()}.wav`;
-  const outputName = `output-${crypto.randomUUID()}.mp3`;
+  const inputName = `input-${Math.random().toString(36).slice(2)}.wav`;
+  const outputName = `output-${Math.random().toString(36).slice(2)}.mp3`;
 
   ffmpeg.writeFile(inputName, new Uint8Array(wavBuffer));
   await ffmpeg.exec(["-i", inputName, "-b:a", "192k", outputName]);

--- a/src/lib/shared/ffmpeg/wavToMp3.ts
+++ b/src/lib/shared/ffmpeg/wavToMp3.ts
@@ -7,13 +7,15 @@ export async function wavToMp3(wavBuffer: ArrayBuffer): Promise<ArrayBuffer> {
 
 async function wavToMp3Client(wavBuffer: ArrayBuffer): Promise<ArrayBuffer> {
   const ffmpeg = await getClientFfmpeg();
-  const inputName = `input-${Math.random().toString(36).slice(2)}.wav`;
-  const outputName = `output-${Math.random().toString(36).slice(2)}.mp3`;
+  const inputName = `input-${Date.now()}-${Math.random().toString(36).slice(2)}.wav`;
+  const outputName = `output-${Date.now()}-${Math.random().toString(36).slice(2)}.mp3`;
 
   ffmpeg.writeFile(inputName, new Uint8Array(wavBuffer));
   await ffmpeg.exec(["-i", inputName, "-b:a", "192k", outputName]);
 
   const data = await ffmpeg.readFile(outputName, "binary");
+  await ffmpeg.deleteFile(inputName).catch(() => {});
+  await ffmpeg.deleteFile(outputName).catch(() => {});
   if (typeof data === "string") throw new Error("Expected binary data");
 
   return data.buffer as ArrayBuffer;


### PR DESCRIPTION
Switches from `crypto.randomUUID()` to `Math.random().toString(36).slice(2)` for generating temporary input and output filenames in FFmpeg client-side operations. This provides a simpler and potentially more lightweight method for creating unique file identifiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved temporary file handling for WAV/MP3 audio processing to streamline naming and lifecycle.
* **Bug Fixes**
  * Added automatic cleanup of temporary audio files after processing to reduce leftover files and resource use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->