### PR TITLE
docs: clarify env vars in inline docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - KW_SECRET_API_KEY=your-api-key
+      - KW_SECRET_API_KEY=your-api-key  # Add authentication to your locally running instance
+      - KW_PUBLIC_NO_TRACK=false  # Opt in ("false") or out ("true") of anonymous usage analytics
     volumes:
       - ./kokoro-cache:/kokoro/cache  # Cache downloaded models and voices
     restart: unless-stopped


### PR DESCRIPTION
Added comments to environment variables `KW_SECRET_API_KEY` and `KW_PUBLIC_NO_TRACK` for clarity of purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Docker usage example to document the `KW_PUBLIC_NO_TRACK` setting.
  * Clarified authentication and anonymous usage-analytics configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->